### PR TITLE
Remove unecessary reference to doaj_transporter settings.json

### DIFF
--- a/plugins/ezid/plugin_settings.py
+++ b/plugins/ezid/plugin_settings.py
@@ -43,9 +43,6 @@ def install():
 
     if created:
         print('Plugin {0} installed.'.format(PLUGIN_NAME))
-        update_settings(
-            file_path='plugins/doaj_transporter/install/settings.json'
-        )
     elif plugin.version != VERSION:
         print('Plugin updated: {0} -> {1}'.format(VERSION, plugin.version))
         plugin.version = VERSION


### PR DESCRIPTION
The doaj_transporter settings.json file path update was inadvertently copied from the doaj_transporter plugin example code. It's not necessary to this plugin. It's mostly harmless, as long as you also have the doaj_transporter plugin installed alongside this plugin, but that's not the case everywhere (and certainly isn't the case on my dev environment). So, this should be removed.