### PR TITLE
Use author.account for all contributor metadata

### DIFF
--- a/plugins/ezid/logic.py
+++ b/plugins/ezid/logic.py
@@ -14,6 +14,7 @@ import json
 # import pdb # use for debugging
 from django.core.validators import URLValidator, ValidationError
 from django.conf import settings
+from django.utils import timezone
 from django.template.loader import render_to_string
 from utils.logger import get_logger
 
@@ -159,6 +160,9 @@ def mint_doi_via_ezid(ezid_config, ezid_metadata):
     # ezid_config dictionary contains values for the following keys: shoulder, username, password, endpoint_url
     # ezid_data dicitionary contains values for the following keys: target_url, group_title, contributors, title, published_date, accepted_date
 
+    # add a timestamp to our metadata, we'll need it
+    ezid_metadata['now'] = timezone.now()
+
     if ezid_metadata.get('published_doi') is not None:
         #we cannot trust that the published_doi has been validated, or is usable as a URL, so let's do that now
         logger.debug('validating published_doi')
@@ -197,6 +201,9 @@ def update_doi_via_ezid(ezid_config, ezid_metadata):
     ''' Sends an update request for the specified config, using the provided data '''
     # ezid_config dictionary contains values for the following keys: shoulder, username, password, endpoint_url
     # ezid_metadata dicitionary contains values for the following keys: update_id, target_url, group_title, contributors, title, published_date, accepted_date
+
+    # add a timestamp to our metadata, we'll need it
+    ezid_metadata['now'] = timezone.now()
 
     if ezid_metadata.get('published_doi') is not None:
         #we cannot trust that the published_doi has been validated, or is usable as a URL, so let's do that now

--- a/plugins/ezid/logic.py
+++ b/plugins/ezid/logic.py
@@ -45,11 +45,7 @@ def normalize_author_metadata(preprint_authors):
         # build our new_author dictionary
         new_author = dict()
 
-        # Newer versions of Janeway use account objects instead of author objects, let's check author first, then try account
-        if author.author is not None:
-            contributor = author.author
-        else:
-            contributor = author.account
+        contributor = author.account
 
         if contributor is None:
             logger.warn('A Preprintauthor.account object is None, this should not be possible... skipping null author.')

--- a/plugins/ezid/templates/ezid/posted_content.xml
+++ b/plugins/ezid/templates/ezid/posted_content.xml
@@ -18,9 +18,9 @@
     <title>{{ title|striptags|escape }}</title>
   </titles>
   <posted_date>
-    <month>{% if published_date %}{{ published_date.month }}{% else %}{{ now.month }}{% endif %}</month>
-    <day>{% if published_date %}{{ published_date.day }}{% else %}{{ now.day }}{% endif %}</day>
-    <year>{% if published_date %}{{ published_date.year }}{% else %}{{ now.year }}{% endif %}</year>
+    <month>{{ now.month }}</month>
+    <day>{{ now.day }}</day>
+    <year>{{ now.year }}</year>
   </posted_date>
   <acceptance_date>
     <month>{% if accepted_date %}{{ accepted_date.month }}{% else %}{{ now.month }}{% endif %}</month>


### PR DESCRIPTION
Now that we're officially on a newer version of Janeway, we need to
always use author.account for our author metadata, the author.author
object is no longer useful for this purpose.